### PR TITLE
fixing syntax error in application.rb

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,7 @@ module Rails3BootstrapDeviseCancan
     # don't generate RSpec tests for views and helpers
     config.generators do |g|
       
-      g.test_framework :rspec, fixture: true
+      g.test_framework :rspec, :fixture => true
       g.fixture_replacement :factory_girl
       
       


### PR DESCRIPTION
I've got this error after running "rails server":
config/application.rb:24: syntax error, unexpected ':', expecting kEND (SyntaxError)
 g.test_framework :rspec, fixture: true

Now it works, for me
