### PR TITLE
Fixed a bug where changing the password of the :user factory would cause the Cucumber specs to break.

### DIFF
--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -19,7 +19,7 @@ end
 def create_user
   create_visitor
   delete_user
-  @user = FactoryGirl.create(:user, email: @visitor[:email])
+  @user = FactoryGirl.create(:user, @visitor)
 end
 
 def delete_user


### PR DESCRIPTION
Changing the default `:user` password for the `factories/users.rb` will causes errors, because the `user_steps.rb` definitions uses it's own default password that only by coincidence is the same as the user factory. This will cause the Cucumber specs to fail.

I changed it to simply load the `@visitor` hash as options when creating a user. It seems to make more sense anyway since the visitor is used elsewhere. You could also write out the full `password: @visitor[:password], password_confirmation: @visitor[:password_confirmation]` but that seems clunkier.

A minor bug, but it cost me a few hours of frustration, so hopefully this will save someone else the trouble.
